### PR TITLE
Refactor skeleton

### DIFF
--- a/PMF.cpp
+++ b/PMF.cpp
@@ -1,51 +1,58 @@
 #include "PMF.h"
 
-PMF::PMF(MatrixXd _data, int _k, double _std_theta, double _std_beta) {
-    data = _data;
-    k = _k;
-    std_beta = _std_beta;
-    std_theta = _std_theta;
-    losses.clear();
+namespace Proj
+{
 
-    default_random_engine generator(time(nullptr));
-    normal_distribution<double> dist_beta(0, std_beta);
-    normal_distribution<double> dist_theta(0, std_theta);
+    PMF::PMF(MatrixXd data, int k, double std_beta, double std_theta)
+        : m_data(data), m_k(k), m_std_beta(std_beta), m_std_theta(std_theta)
+    {
+        default_random_engine generator(time(nullptr));
+        normal_distribution<double> dist_beta(0, std_beta);
+        normal_distribution<double> dist_theta(0, std_theta);
 
-    for (int i = 0; i < k; i++) {
-        beta.push_back(dist_beta(generator));
-        theta.push_back(dist_theta(generator));
+        for (int i = 0; i < k; i++)
+        {
+            m_beta.push_back(dist_beta(generator));
+            m_theta.push_back(dist_theta(generator));
+        }
     }
-}
 
-double PMF::normPDF(int x, double loc, double scale) {
-    cerr << "Not implemented yet" << endl;
-    return 0;
-}
+    double PMF::normPDF(int x, double loc, double scale)
+    {
+        cerr << "Not implemented yet" << endl;
+        return 0;
+    }
 
-double PMF::logNormPDF(int x, double loc, double scale) {
-    cerr << "Not implemented yet" << endl;
-    return 0;
-}
+    double PMF::logNormPDF(int x, double loc, double scale)
+    {
+        cerr << "Not implemented yet" << endl;
+        return 0;
+    }
 
-double PMF::gradLogNormPDF(int x, double loc, double scale) {
-    cerr << "Not implemented yet" << endl;
-    return 0;
-}
+    double PMF::gradLogNormPDF(int x, double loc, double scale)
+    {
+        cerr << "Not implemented yet" << endl;
+        return 0;
+    }
 
-vector<double> PMF::loss(MatrixXd _data) {
-    cerr << "Not implemented yet" << endl;
-    vector<double> tmp {};
-    return tmp;
-}
+    vector<double> PMF::loss(MatrixXd data)
+    {
+        cerr << "Not implemented yet" << endl;
+        return {};
+    }
 
-MatrixXd PMF::predict(MatrixXd _data) {
-    cerr << "Not implemented yet" << endl;
-    MatrixXd m(1,1);
-    return m;
-}
+    MatrixXd PMF::predict(MatrixXd data)
+    {
+        cerr << "Not implemented yet" << endl;
+        MatrixXd m(1, 1);
+        return m;
+    }
 
-VectorXd PMF::recommend(int user) {
-    cerr << "Not implemented yet" << endl;
-    VectorXd v;
-    return v;
-}
+    VectorXd PMF::recommend(int user)
+    {
+        cerr << "Not implemented yet" << endl;
+        VectorXd v;
+        return v;
+    }
+
+} //namespace Proj

--- a/PMF.h
+++ b/PMF.h
@@ -4,28 +4,33 @@
 #include <iostream>
 #include <Eigen/Dense>
 #include <random>
-using namespace std;
-using namespace Eigen;
 
-class PMF {
-private:
-    double k;
-    double std_theta;
-    double std_beta;
-    vector<double> beta {};
-    vector<double> theta {};
-    vector<double> losses {};
-    MatrixXd data;
+namespace Proj
+{
+    using namespace std;
+    using namespace Eigen;
 
-public:
-    PMF(MatrixXd d, int n_components, double eta_theta, double eta_beta);
-    ~PMF();
-    double normPDF(int x, double loc=0.0, double scale=1.0);
-    double logNormPDF(int x, double loc=0.0, double scale=1.0);
-    double gradLogNormPDF(int x, double loc=0.0, double scale=1.0);
-    vector<double> loss(MatrixXd _data);
-    MatrixXd predict(MatrixXd _data);
-    VectorXd recommend(int user);
+    class PMF
+    {
+    private:
+        MatrixXd m_data;
+        double m_k;
+        double m_std_theta;
+        double m_std_beta;
+        vector<double> m_beta;
+        vector<double> m_theta;
+        vector<double> m_losses;
 
-    //todo: specify return type for "norm_vectors" functions in model.py
-};
+    public:
+        PMF(MatrixXd d, int k, double eta_beta, double eta_theta);
+        ~PMF();
+        double normPDF(int x, double loc = 0.0, double scale = 1.0);
+        double logNormPDF(int x, double loc = 0.0, double scale = 1.0);
+        double gradLogNormPDF(int x, double loc = 0.0, double scale = 1.0);
+        vector<double> loss(MatrixXd data);
+        MatrixXd predict(MatrixXd data);
+        VectorXd recommend(int user);
+
+        //todo: specify return type for "norm_vectors" functions in model.py
+    };
+} //namespace Proj

--- a/main.cpp
+++ b/main.cpp
@@ -7,6 +7,7 @@
 #include <boost/filesystem.hpp>
 #include "csvlib/csv.h"
 #include <Eigen/Dense>
+
 using namespace std;
 using namespace Eigen;
 
@@ -19,9 +20,11 @@ namespace fs = boost::filesystem;
  * @param input path to input data file
  * @return processed matrix
  */
-MatrixXd loadData(const string &input) {
+MatrixXd loadData(const string &input)
+{
     // todo: the number of cols to take in the current CSV parser isn't flexible; no need to worry if we always read 3 cols
-    if (!fs::exists(input)) {
+    if (!fs::exists(input))
+    {
         cerr << "Can't find the given input file: " << input << endl;
         exit(1);
     }
@@ -33,60 +36,61 @@ MatrixXd loadData(const string &input) {
     double rating;
     MatrixXd ratings(1, 3);
 
-    while (in.read_row(user_id, movie_id, rating)) {
+    while (in.read_row(user_id, movie_id, rating))
+    {
         Vector3d curr;
         curr << user_id, movie_id, rating;
-        ratings.row(ratings.rows()-1) = curr;
-        ratings.conservativeResize(ratings.rows()+1, ratings.cols());
+        ratings.row(ratings.rows() - 1) = curr;
+        ratings.conservativeResize(ratings.rows() + 1, ratings.cols());
     }
-    ratings.conservativeResize(ratings.rows()-1, ratings.cols());
+    ratings.conservativeResize(ratings.rows() - 1, ratings.cols());
 
     // center ratings to mean = 0
     set<double> unique_rates{ratings.col(2).data(), ratings.col(2).data() + ratings.col(2).size()};
     double sum = 0;
-    for (auto i : unique_rates) {
+    for (auto i : unique_rates)
+    {
         sum += i;
     }
     double mid = sum / unique_rates.size();
-    for (int i = 0; i < ratings.rows(); i++) {
+    for (int i = 0; i < ratings.rows(); i++)
+    {
         ratings(i, 2) -= mid;
     }
 
     return ratings;
 }
 
-
-int main(int argc, char **argv) {
+int main(int argc, char **argv)
+{
     // parse arguments, path configuration
     string input;
     fs::path outdir("results");
     int k;
-    int n_epochs = 200; // default # of iterations
+    int n_epochs = 200;  // default # of iterations
     double gamma = 0.01; // default learning rate for gradient descent
 
     po::options_description desc("Parameters for Probabilistic Matrix Factorization (PMF)");
-    desc.add_options()
-            ("help,h", "Help")
-            ("input,i", po::value<string>(&input), "Input file name")
-            ("output,o", po::value<fs::path>(&outdir), "Output directory\n  [default: current_path/results/]")
-            ("n_components,k", po::value<int>(&k), "Number of components (k)")
-            ("n_epochs,n", po::value<int>(&n_epochs), "Num. of learning iterations\n  [default: 200]")
-            ("gamma", po::value<double>(&gamma), "learning rate for gradient descent\n  [default: 1e-2]")
-            ;
+    desc.add_options()("help,h", "Help")("input,i", po::value<string>(&input), "Input file name")("output,o", po::value<fs::path>(&outdir), "Output directory\n  [default: current_path/results/]")("n_components,k", po::value<int>(&k), "Number of components (k)")("n_epochs,n", po::value<int>(&n_epochs), "Num. of learning iterations\n  [default: 200]")("gamma", po::value<double>(&gamma), "learning rate for gradient descent\n  [default: 1e-2]");
     po::variables_map vm;
     po::store(po::parse_command_line(argc, argv, desc), vm);
     po::notify(vm);
 
-    if (vm.count("help")) {
+    if (vm.count("help"))
+    {
         cout << desc << endl;
         return 0;
     }
-    if (outdir.empty()) {
+    if (outdir.empty())
+    {
         outdir = "results";
     }
-    if (!fs::exists(outdir)) {
+    if (!fs::exists(outdir))
+    {
         cout << "Outdir " << outdir << " exists" << endl;
-    } else {
+    }
+    else
+    {
         cout << "Outdir doesn't exist, creating " << outdir << "..." << endl;
         fs::create_directory(outdir);
     }


### PR DESCRIPTION
Changes:
1) Add namespace `Proj`  around PMF classes. 
Reasoning: Should not be using `using namespace ...` in the global space of a header file:
https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf7-dont-write-using-namespace-at-global-scope-in-a-header-file

2) Renamed member variables to be prefixed with `m_` to represent "Member"
Reasoning: This is more of personal taste but I think it is less confusing in the function implementation so that we know that `m_*` always indicates it is a member variable. Also it prevents us from having to prefix `_` all the parameters in the function implementations.

3) Make PMF constructor use initializer lists. 
Reasoning: Should be using initializer lists when we can in the constructor. Also, the order of the initializer list should be the same as the order of declaration of private member variables in the class. This is to avoid confusion, as the compiler will initialize the member variables  in the  order it is declared in the class, not the order of the initializer list.
See: https://isocpp.github.io/CppCoreGuidelines/CppCoreGuidelines#sf7-dont-write-using-namespace-at-global-scope-in-a-header-file
